### PR TITLE
Add quiet output mode for scripting (-q flag)

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/yeya/wire-seek/mtu"
+	"github.com/yeya/wire-seek/output"
 )
 
 func main() {
@@ -14,11 +15,13 @@ func main() {
 		target  string
 		ipv6    bool
 		verbose bool
+		quiet   bool
 	)
 
 	flag.StringVar(&target, "target", "", "Target host or IP address (required)")
 	flag.BoolVar(&ipv6, "6", false, "Use IPv6 instead of IPv4")
-	flag.BoolVar(&verbose, "v", false, "Verbose output")
+	flag.BoolVar(&verbose, "v", false, "Verbose output (debug diagnostics)")
+	flag.BoolVar(&quiet, "q", false, "Quiet output (only print MTU value, for scripting)")
 	flag.Parse()
 
 	if target == "" {
@@ -26,50 +29,64 @@ func main() {
 		if flag.NArg() > 0 {
 			target = flag.Arg(0)
 		} else {
-			fmt.Fprintf(os.Stderr, "Usage: wire-seek [-6] [-v] -target <host>\n")
-			fmt.Fprintf(os.Stderr, "       wire-seek [-6] [-v] <host>\n\n")
+			fmt.Fprintf(os.Stderr, "Usage: wire-seek [-6] [-v] [-q] -target <host>\n")
+			fmt.Fprintf(os.Stderr, "       wire-seek [-6] [-v] [-q] <host>\n\n")
 			fmt.Fprintf(os.Stderr, "Options:\n")
 			flag.PrintDefaults()
 			os.Exit(1)
 		}
 	}
 
+	// Determine output level (quiet takes precedence if both are specified)
+	level := output.LevelNormal
+	if quiet {
+		level = output.LevelQuiet
+	} else if verbose {
+		level = output.LevelVerbose
+	}
+	log := output.New(level)
+
 	// Resolve target to IP address
 	ip, err := resolveTarget(target, ipv6)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error resolving target: %v\n", err)
+		log.Error("Error resolving target: %v\n", err)
 		os.Exit(1)
 	}
 
 	isIPv6 := ip.To4() == nil
 
-	fmt.Printf("Wire-Seek: WireGuard MTU Optimizer\n")
-	fmt.Printf("Target: %s (%s)\n", target, ip.String())
+	log.Info("Wire-Seek: WireGuard MTU Optimizer\n")
+	log.Info("Target: %s (%s)\n", target, ip.String())
 	if isIPv6 {
-		fmt.Printf("Protocol: IPv6\n")
+		log.Info("Protocol: IPv6\n")
 	} else {
-		fmt.Printf("Protocol: IPv4\n")
+		log.Info("Protocol: IPv4\n")
 	}
-	fmt.Println()
+	log.Info("\n")
 
 	// Perform MTU discovery
-	discoverer := mtu.NewDiscoverer(ip, verbose)
+	discoverer := mtu.NewDiscoverer(ip, log)
 	pathMTU, err := discoverer.FindPathMTU()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error discovering MTU: %v\n", err)
+		log.Error("Error discovering MTU: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Calculate WireGuard MTU
 	wgMTU := mtu.CalculateWireGuardMTU(pathMTU, isIPv6)
 
-	fmt.Println()
-	fmt.Printf("Results:\n")
-	fmt.Printf("  Path MTU:      %d bytes\n", pathMTU)
-	fmt.Printf("  WireGuard MTU: %d bytes\n", wgMTU)
-	fmt.Println()
-	fmt.Printf("Add to your WireGuard config:\n")
-	fmt.Printf("  MTU = %d\n", wgMTU)
+	log.Info("\n")
+	log.Info("Results:\n")
+	log.Info("  Path MTU:      %d bytes\n", pathMTU)
+	log.Info("  WireGuard MTU: %d bytes\n", wgMTU)
+	log.Info("\n")
+	log.Info("Add to your WireGuard config:\n")
+	log.Info("  MTU = %d\n", wgMTU)
+
+	// In quiet mode, output only the MTU value
+	if quiet {
+		log.Result("%d\n", wgMTU)
+	}
 }
 
 // resolveTarget resolves a hostname or IP string to a net.IP

--- a/mtu/discover.go
+++ b/mtu/discover.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/yeya/wire-seek/output"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -31,17 +32,17 @@ const (
 
 // Discoverer handles MTU discovery operations
 type Discoverer struct {
-	target  net.IP
-	isIPv6  bool
-	verbose bool
+	target net.IP
+	isIPv6 bool
+	log    *output.Logger
 }
 
 // NewDiscoverer creates a new MTU discoverer for the given target
-func NewDiscoverer(target net.IP, verbose bool) *Discoverer {
+func NewDiscoverer(target net.IP, log *output.Logger) *Discoverer {
 	return &Discoverer{
-		target:  target,
-		isIPv6:  target.To4() == nil,
-		verbose: verbose,
+		target: target,
+		isIPv6: target.To4() == nil,
+		log:    log,
 	}
 }
 
@@ -53,7 +54,7 @@ func (d *Discoverer) FindPathMTU() (int, error) {
 	}
 	high := MaxMTU
 
-	fmt.Printf("Discovering path MTU (range: %d-%d)...\n", low, high)
+	d.log.Info("Discovering path MTU (range: %d-%d)...\n", low, high)
 
 	// First, verify we can reach the target at all
 	if !d.canSendSize(low) {
@@ -64,19 +65,13 @@ func (d *Discoverer) FindPathMTU() (int, error) {
 	for low < high-1 {
 		mid := (low + high + 1) / 2
 
-		if d.verbose {
-			fmt.Printf("  Testing MTU %d... ", mid)
-		}
+		d.log.Debug("  Testing MTU %d... ", mid)
 
 		if d.canSendSize(mid) {
-			if d.verbose {
-				fmt.Printf("OK\n")
-			}
+			d.log.Debug("OK\n")
 			low = mid
 		} else {
-			if d.verbose {
-				fmt.Printf("Too large\n")
-			}
+			d.log.Debug("Too large\n")
 			high = mid - 1
 		}
 	}
@@ -136,24 +131,20 @@ func (d *Discoverer) pingWithDF(payloadSize int) bool {
 		}
 		conn, err = icmp.ListenPacket(network, "")
 		if err != nil {
-			if d.verbose {
-				fmt.Fprintf(os.Stderr, "Warning: failed to create ICMP socket: %v\n", err)
-			}
+			d.log.Debug("Warning: failed to create ICMP socket: %v\n", err)
 			return false
 		}
-		if d.verbose {
-			fmt.Fprintf(os.Stderr, "  Using unprivileged ICMP (%s)\n", network)
-		}
-	} else if d.verbose {
-		fmt.Fprintf(os.Stderr, "  Using raw ICMP socket (%s)\n", network)
+		d.log.Debug("  Using unprivileged ICMP (%s)\n", network)
+	} else {
+		d.log.Debug("  Using raw ICMP socket (%s)\n", network)
 	}
 	defer conn.Close()
 
 	// Set Don't Fragment bit for IPv4 using the ipv4 package
 	if !d.isIPv6 {
 		p := conn.IPv4PacketConn()
-		if err := setDontFragmentIPv4(p); err != nil && d.verbose {
-			fmt.Fprintf(os.Stderr, "Warning: failed to set DF bit: %v\n", err)
+		if err := setDontFragmentIPv4(p); err != nil {
+			d.log.Debug("Warning: failed to set DF bit: %v\n", err)
 		}
 	}
 
@@ -170,17 +161,13 @@ func (d *Discoverer) pingWithDF(payloadSize int) bool {
 
 	msgBytes, err := msg.Marshal(nil)
 	if err != nil {
-		if d.verbose {
-			fmt.Fprintf(os.Stderr, "  Error marshaling ICMP message: %v\n", err)
-		}
+		d.log.Debug("  Error marshaling ICMP message: %v\n", err)
 		return false
 	}
 
 	// Set deadline
 	if err := conn.SetDeadline(time.Now().Add(pingTimeout)); err != nil {
-		if d.verbose {
-			fmt.Fprintf(os.Stderr, "  Error setting deadline: %v\n", err)
-		}
+		d.log.Debug("  Error setting deadline: %v\n", err)
 		return false
 	}
 
@@ -199,9 +186,7 @@ func (d *Discoverer) pingWithDF(payloadSize int) bool {
 
 	// Send packet
 	if _, err := conn.WriteTo(msgBytes, dst); err != nil {
-		if d.verbose {
-			fmt.Fprintf(os.Stderr, "  Error sending packet: %v\n", err)
-		}
+		d.log.Debug("  Error sending packet: %v\n", err)
 		return false
 	}
 
@@ -209,32 +194,28 @@ func (d *Discoverer) pingWithDF(payloadSize int) bool {
 	reply := make([]byte, 1500)
 	n, _, err := conn.ReadFrom(reply)
 	if err != nil {
-		if d.verbose {
-			fmt.Fprintf(os.Stderr, "  Error reading reply: %v\n", err)
-		}
+		d.log.Debug("  Error reading reply: %v\n", err)
 		return false
 	}
 
 	// Parse reply
 	rm, err := icmp.ParseMessage(proto, reply[:n])
 	if err != nil {
-		if d.verbose {
-			fmt.Fprintf(os.Stderr, "  Error parsing reply: %v\n", err)
-		}
+		d.log.Debug("  Error parsing reply: %v\n", err)
 		return false
 	}
 
 	// Check if it's an echo reply
 	if d.isIPv6 {
 		success := rm.Type == ipv6.ICMPTypeEchoReply
-		if d.verbose && !success {
-			fmt.Fprintf(os.Stderr, "  Received unexpected ICMP type: %v\n", rm.Type)
+		if !success {
+			d.log.Debug("  Received unexpected ICMP type: %v\n", rm.Type)
 		}
 		return success
 	}
 	success := rm.Type == ipv4.ICMPTypeEchoReply
-	if d.verbose && !success {
-		fmt.Fprintf(os.Stderr, "  Received unexpected ICMP type: %v\n", rm.Type)
+	if !success {
+		d.log.Debug("  Received unexpected ICMP type: %v\n", rm.Type)
 	}
 	return success
 }

--- a/mtu/discover_test.go
+++ b/mtu/discover_test.go
@@ -3,43 +3,39 @@ package mtu
 import (
 	"net"
 	"testing"
+
+	"github.com/yeya/wire-seek/output"
 )
 
 func TestNewDiscoverer(t *testing.T) {
 	tests := []struct {
-		name       string
-		target     net.IP
-		verbose    bool
-		wantIPv6   bool
+		name     string
+		target   net.IP
+		wantIPv6 bool
 	}{
 		{
 			name:     "IPv4 address",
 			target:   net.ParseIP("8.8.8.8"),
-			verbose:  false,
 			wantIPv6: false,
 		},
 		{
 			name:     "IPv6 address",
 			target:   net.ParseIP("2001:4860:4860::8888"),
-			verbose:  true,
 			wantIPv6: true,
 		},
 		{
 			name:     "IPv4-mapped IPv6 treated as IPv4",
 			target:   net.ParseIP("::ffff:8.8.8.8").To4(),
-			verbose:  false,
 			wantIPv6: false,
 		},
 	}
 
+	log := output.New(output.LevelNormal)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := NewDiscoverer(tt.target, tt.verbose)
+			d := NewDiscoverer(tt.target, log)
 			if d.isIPv6 != tt.wantIPv6 {
 				t.Errorf("NewDiscoverer().isIPv6 = %v, want %v", d.isIPv6, tt.wantIPv6)
-			}
-			if d.verbose != tt.verbose {
-				t.Errorf("NewDiscoverer().verbose = %v, want %v", d.verbose, tt.verbose)
 			}
 		})
 	}

--- a/output/output.go
+++ b/output/output.go
@@ -1,0 +1,65 @@
+// Package output provides a simple leveled output system for CLI applications.
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Level represents the verbosity level
+type Level int
+
+const (
+	// LevelQuiet outputs only essential results (for scripting)
+	LevelQuiet Level = iota
+	// LevelNormal outputs standard progress and results
+	LevelNormal
+	// LevelVerbose outputs detailed diagnostic information
+	LevelVerbose
+)
+
+// Logger handles leveled output
+type Logger struct {
+	level  Level
+	out    io.Writer
+	errOut io.Writer
+}
+
+// New creates a new Logger with the specified verbosity level
+func New(level Level) *Logger {
+	return &Logger{
+		level:  level,
+		out:    os.Stdout,
+		errOut: os.Stderr,
+	}
+}
+
+// Level returns the current verbosity level
+func (l *Logger) Level() Level {
+	return l.level
+}
+
+// Debug prints diagnostic output (only in verbose mode)
+func (l *Logger) Debug(format string, args ...interface{}) {
+	if l.level >= LevelVerbose {
+		fmt.Fprintf(l.out, format, args...)
+	}
+}
+
+// Info prints standard progress information (normal and verbose modes)
+func (l *Logger) Info(format string, args ...interface{}) {
+	if l.level >= LevelNormal {
+		fmt.Fprintf(l.out, format, args...)
+	}
+}
+
+// Result prints output that is always shown regardless of level
+func (l *Logger) Result(format string, args ...interface{}) {
+	fmt.Fprintf(l.out, format, args...)
+}
+
+// Error prints error messages to stderr (always shown)
+func (l *Logger) Error(format string, args ...interface{}) {
+	fmt.Fprintf(l.errOut, format, args...)
+}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,0 +1,143 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name  string
+		level Level
+	}{
+		{"Quiet level", LevelQuiet},
+		{"Normal level", LevelNormal},
+		{"Verbose level", LevelVerbose},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := New(tt.level)
+			if log.Level() != tt.level {
+				t.Errorf("New(%v).Level() = %v, want %v", tt.level, log.Level(), tt.level)
+			}
+		})
+	}
+}
+
+func TestDebug(t *testing.T) {
+	tests := []struct {
+		name       string
+		level      Level
+		wantOutput bool
+	}{
+		{"Quiet suppresses debug", LevelQuiet, false},
+		{"Normal suppresses debug", LevelNormal, false},
+		{"Verbose shows debug", LevelVerbose, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := New(tt.level)
+			log.out = &buf
+
+			log.Debug("test message")
+
+			hasOutput := buf.Len() > 0
+			if hasOutput != tt.wantOutput {
+				t.Errorf("Debug() output = %v, want output = %v", hasOutput, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		level      Level
+		wantOutput bool
+	}{
+		{"Quiet suppresses info", LevelQuiet, false},
+		{"Normal shows info", LevelNormal, true},
+		{"Verbose shows info", LevelVerbose, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := New(tt.level)
+			log.out = &buf
+
+			log.Info("test message")
+
+			hasOutput := buf.Len() > 0
+			if hasOutput != tt.wantOutput {
+				t.Errorf("Info() output = %v, want output = %v", hasOutput, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestResult(t *testing.T) {
+	tests := []struct {
+		name  string
+		level Level
+	}{
+		{"Quiet shows result", LevelQuiet},
+		{"Normal shows result", LevelNormal},
+		{"Verbose shows result", LevelVerbose},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := New(tt.level)
+			log.out = &buf
+
+			log.Result("test message")
+
+			if buf.Len() == 0 {
+				t.Errorf("Result() should always output, got empty buffer")
+			}
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		name  string
+		level Level
+	}{
+		{"Quiet shows error", LevelQuiet},
+		{"Normal shows error", LevelNormal},
+		{"Verbose shows error", LevelVerbose},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := New(tt.level)
+			log.errOut = &buf
+
+			log.Error("test error")
+
+			if buf.Len() == 0 {
+				t.Errorf("Error() should always output to stderr, got empty buffer")
+			}
+		})
+	}
+}
+
+func TestFormatting(t *testing.T) {
+	var buf bytes.Buffer
+	log := New(LevelVerbose)
+	log.out = &buf
+
+	log.Info("value: %d, string: %s", 42, "hello")
+
+	expected := "value: 42, string: hello"
+	if buf.String() != expected {
+		t.Errorf("Info() = %q, want %q", buf.String(), expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a new `-q` (quiet) flag that outputs only the MTU value for scripting
- Introduces a proper leveled output system with Quiet/Normal/Verbose levels
- Refactors the codebase to use the new output package instead of boolean verbose flag

## Usage
```bash
# Quiet mode - outputs only the MTU value
$ wire-seek -q vpn.example.com
1440

# Normal mode (default)
$ wire-seek vpn.example.com
Wire-Seek: WireGuard MTU Optimizer
Target: vpn.example.com (1.2.3.4)
...

# Verbose mode - detailed diagnostics
$ wire-seek -v vpn.example.com
```

## Test plan
- [x] All existing tests pass
- [x] New output package tests added and passing
- [x] Tested `-q` flag outputs only MTU value
- [x] Tested default mode works as before
- [x] Tested `-v` flag shows debug output

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)